### PR TITLE
 Updated versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,28 +14,28 @@
   "main": "index.js",
   "types": "./types/index.d.ts",
   "dependencies": {
-    "anymatch": "~3.1.2",
-    "braces": "~3.0.2",
-    "glob-parent": "~5.1.2",
-    "is-binary-path": "~2.1.0",
-    "is-glob": "~4.0.1",
+    "anymatch": "~3.1.3",
+    "braces": "~3.0.3",
+    "glob-parent": "~6.0.2",
+    "is-binary-path": "~3.0.0",
+    "is-glob": "~4.0.3",
     "normalize-path": "~3.0.0",
     "readdirp": "~3.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "~2.3.2"
+    "fsevents": "~2.3.3"
   },
   "devDependencies": {
-    "@types/node": "^14",
-    "chai": "^4.3",
-    "dtslint": "^3.3.0",
-    "eslint": "^7.0.0",
-    "mocha": "^7.0.0",
-    "rimraf": "^3.0.0",
-    "sinon": "^9.0.1",
-    "sinon-chai": "^3.3.0",
-    "typescript": "^4.4.3",
-    "upath": "^1.2.0"
+    "@types/node": "^20",
+    "chai": "^5.1",
+    "dtslint": "^4.2.1",
+    "eslint": "^9.4.0",
+    "mocha": "^10.4.0",
+    "rimraf": "^5.0.7",
+    "sinon": "^18.0.0",
+    "sinon-chai": "^3.7.0",
+    "typescript": "^5.4.5",
+    "upath": "^2.0.1"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
 @types/node        ^14  →      ^20
 anymatch        ~3.1.2  →   ~3.1.3
 braces          ~3.0.2  →   ~3.0.3
 chai              ^4.3  →     ^5.1
 dtslint         ^3.3.0  →   ^4.2.1
 eslint          ^7.0.0  →   ^9.4.0
 fsevents        ~2.3.2  →   ~2.3.3
 glob-parent     ~5.1.2  →   ~6.0.2
 is-binary-path  ~2.1.0  →   ~3.0.0
 is-glob         ~4.0.1  →   ~4.0.3
 mocha           ^7.0.0  →  ^10.4.0
 rimraf          ^3.0.0  →   ^5.0.7
 sinon           ^9.0.1  →  ^18.0.0
 sinon-chai      ^3.3.0  →   ^3.7.0
 typescript      ^4.4.3  →   ^5.4.5
 upath           ^1.2.0  →   ^2.0.1